### PR TITLE
Update redtornado.yml

### DIFF
--- a/CommandHelper/LocalPackages/commands/chars/redtornado.yml
+++ b/CommandHelper/LocalPackages/commands/chars/redtornado.yml
@@ -16,6 +16,7 @@ permissions:
   superherocity:
   - ch.alias.carryplayer
   - ch.alias.dismountplayer
+  - essentials.fly
 powers:
 - /buff
 - /fly


### PR DESCRIPTION
Red Tornado had /fly listed in powers, but it wasn't added to permissions.

https://upload.wikimedia.org/wikipedia/en/7/70/Red_Tornado_%28Ed_Benes%27s_art%29.png - Flying